### PR TITLE
feat: allow https localhost origin for CORS to support HTTPS frontend

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,8 @@ const corsOptions = {
     const allowedOrigins = [
       process.env.FRONTEND_URL,
       process.env.FRONTEND_URL_DEV,
+      'http://localhost:5173',
+      'https://localhost:5173',
     ];
 
     if (allowedOrigins.includes(origin) || !origin) {


### PR DESCRIPTION
Frontend now runs on https://localhost:5173 via vite-plugin-mkcert 
to enable phone camera access for barcode scanning.

Added https://localhost:5173 to CORS allowedOrigins so the HTTPS 
frontend can call the backend. http://localhost:5173 still works.