### PR TITLE
hotfix: post-merge fixups (server crash + scan-out barcode + duplicate column)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ FRONTEND_URL=https://your-production-url.com
 API_URL=http://localhost:5050
 FRONTEND_URL_DEV=http://localhost:5173
 NODE_ENV=development
+
+# Barcode lookup configuration
+OPEN_FOOD_FACTS_USER_AGENT=disc-food-pantry/1.0
+UPCITEMDB_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,4 @@ FRONTEND_URL=https://your-production-url.com
 API_URL=http://localhost:5050
 FRONTEND_URL_DEV=http://localhost:5173
 NODE_ENV=development
-
-# Barcode lookup configuration
-OPEN_FOOD_FACTS_USER_AGENT=disc-food-pantry/1.0
-UPCITEMDB_API_KEY=
+OPEN_FOOD_FACTS_USER_AGENT=disc-food-pantry/1.0 (cameronlam2028@u.northwestern.edu)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ Check out DISC:
 
 ## Stack
 
-Firebase Authentication + Supabase (PostgreSQL) backend template. Can be migrated to AWS RDS (MySQL) — see [SETUP_GUIDE.md](SETUP_GUIDE.md).
+Firebase Authentication + Supabase (PostgreSQL) backend template. Can be
+migrated to AWS RDS (MySQL) — see [SETUP_GUIDE.md](SETUP_GUIDE.md).
 
 - **Runtime**: Node.js with ES Modules
 - **Framework**: Express.js
 - **Authentication**: Firebase Auth (Email/Password + Google OAuth)
 - **Database**: Supabase (PostgreSQL) — switchable to AWS RDS (MySQL)
-- **Database Client**: pg / mysql2 (connection pool, raw SQL with parameterized queries)
+- **Database Client**: pg / mysql2 (connection pool, raw SQL with parameterized
+  queries)
 - **Language**: JavaScript (ES Modules)
 
 ## Quick Start
@@ -53,6 +55,12 @@ See [SETUP_GUIDE.md](SETUP_GUIDE.md) for full setup instructions.
 - `GET /auth/users` - Get all users (protected)
 - `POST /auth/logout` - Logout
 - `POST /auth/token` - Sync Firebase OAuth user to database
+- `POST /api/barcode/lookup` - Resolve a scanned barcode to a product name
+- `POST /api/barcode/set-custom` - Save an admin-defined nickname for a barcode
+- `GET /api/inventory/categories` - Get inventory grouped by category
+- `POST /api/inventory/categories` - Create a new inventory category
+- `GET /api/inventory/items/:itemId` - Get item detail and expiration batches
+- `POST /api/inventory/check-in` - Add scanned inventory into stock
 
 ## Scripts
 
@@ -69,8 +77,8 @@ install the recommended extensions from `.vscode/extensions.json`. Click
 **Install** on the notification, or install them manually:
 
 1. [Prettier ESLint](https://marketplace.visualstudio.com/items?itemName=rvest.vs-code-prettier-eslint)
-   (`rvest.vs-code-prettier-eslint`) — formats your code using both Prettier
-   and ESLint rules on every save
+   (`rvest.vs-code-prettier-eslint`) — formats your code using both Prettier and
+   ESLint rules on every save
 2. [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
    (`dbaeumer.vscode-eslint`) — shows lint errors and warnings inline as you
    type
@@ -95,8 +103,11 @@ Required `.env` variables (see [.env.example](.env.example)):
 - `FRONTEND_URL` - Production frontend URL for CORS
 - `FRONTEND_URL_DEV` - Development frontend URL for CORS
 - `NODE_ENV` - Environment (development/production)
+- `OPEN_FOOD_FACTS_USER_AGENT` - Optional custom user-agent string for barcode lookups
+- `UPCITEMDB_API_KEY` - Optional paid fallback for barcode lookups when Open Food Facts has no match
 
-`rds-config.ini` is only needed when migrating to AWS RDS. See [SETUP_GUIDE.md](SETUP_GUIDE.md).
+`rds-config.ini` is only needed when migrating to AWS RDS. See
+[SETUP_GUIDE.md](SETUP_GUIDE.md).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Required `.env` variables (see [.env.example](.env.example)):
 - `FRONTEND_URL_DEV` - Development frontend URL for CORS
 - `NODE_ENV` - Environment (development/production)
 - `OPEN_FOOD_FACTS_USER_AGENT` - Optional custom user-agent string for barcode lookups
-- `UPCITEMDB_API_KEY` - Optional paid fallback for barcode lookups when Open Food Facts has no match
+- `UPCITEMDB_API_KEY` - Optional UPCItemDB key for higher lookup limits; the no-key free tier is used when omitted
 
 `rds-config.ini` is only needed when migrating to AWS RDS. See
 [SETUP_GUIDE.md](SETUP_GUIDE.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.15.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -1554,8 +1555,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -1564,6 +1564,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/axios/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/balanced-match": {
@@ -1744,7 +1792,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1870,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2007,7 +2053,6 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -2495,6 +2540,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
@@ -2810,7 +2875,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3904,6 +3968,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1227,6 +1227,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1250,9 +1263,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1262,13 +1275,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1278,9 +1290,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1296,15 +1308,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1484,9 +1496,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1567,14 +1579,27 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -1588,6 +1613,19 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"
@@ -1675,9 +1713,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1886,6 +1924,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -2182,9 +2229,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2193,9 +2240,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2375,10 +2422,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
-      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2388,7 +2435,28 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2404,6 +2472,29 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2494,29 +2585,98 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.6.1.tgz",
-      "integrity": "sha512-Zgc6yPtmPxAZo+FoK6LMG6zpSEsoSK8ifIR+IqF4oWuC3uWZU40OjxgfLTSFcsRlj/k/wD66zNv2UiTRreCNSw==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
         "@firebase/database-types": "^1.0.6",
-        "@types/node": "^22.8.7",
         "farmhash-modern": "^1.1.0",
         "fast-deep-equal": "^3.1.1",
-        "google-auth-library": "^9.14.2",
+        "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
-        "@google-cloud/storage": "^7.14.0"
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/flat-cache": {
@@ -2534,9 +2694,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2601,6 +2761,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2640,6 +2812,7 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -2660,6 +2833,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2669,6 +2843,7 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -2764,6 +2939,7 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -2819,6 +2995,7 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -2840,6 +3017,7 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -3113,6 +3291,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -3311,9 +3490,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3490,13 +3669,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3559,11 +3738,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3577,15 +3777,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/object-assign": {
@@ -3739,6 +3930,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3750,9 +3957,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3934,22 +4141,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -4392,9 +4599,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -4495,7 +4702,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4562,19 +4770,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4582,6 +4777,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-vitals": {
@@ -4594,7 +4798,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -4624,6 +4829,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4677,6 +4883,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^1.15.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -72,3 +72,29 @@ ON item_batches (item_id, expiration_date);
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_name
 ON categories (LOWER(name));
+
+INSERT INTO categories (name, parent_group, display_order)
+SELECT seed.name, seed.parent_group, seed.display_order
+FROM (
+  VALUES
+    ('Protein',                         'food',     1),
+    ('Grains/Staples',                  'food',     2),
+    ('Fruits and Vegetables',           'food',     3),
+    ('Dairy',                           'food',     4),
+    ('Frozen Foods',                    'food',     5),
+    ('Meals/Prepared Foods',            'food',     6),
+    ('Snacks',                          'food',     7),
+    ('Breakfast Foods',                 'food',     8),
+    ('Condiments & Cooking Essentials', 'food',     9),
+    ('Specialty/Dietary Items',         'food',     10),
+    ('Baby Items',                      'food',     11),
+    ('Cleaning Supplies',               'non_food', 1),
+    ('Personal Care',                   'non_food', 2),
+    ('Paper Goods',                     'non_food', 3),
+    ('Baby & Child',                    'non_food', 4)
+) AS seed(name, parent_group, display_order)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM categories c
+  WHERE LOWER(c.name) = LOWER(seed.name)
+);

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -1,5 +1,5 @@
 -- Supabase / PostgreSQL
--- Run this in the Supabase SQL Editor (supabase.com → project → SQL Editor)
+-- Run this in the Supabase SQL Editor (supabase.com -> project -> SQL Editor)
 
 CREATE TABLE IF NOT EXISTS users (
   id           SERIAL PRIMARY KEY,
@@ -12,16 +12,47 @@ CREATE TABLE IF NOT EXISTS users (
   updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS barcode_mappings (
+  id          SERIAL PRIMARY KEY,
+  barcode     VARCHAR(50) NOT NULL UNIQUE,
+  custom_name VARCHAR(255) NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS categories (
-  id SERIAL PRIMARY KEY,
-  name TEXT NOT NULL UNIQUE,
-  created_at TIMESTAMP DEFAULT NOW()
+  id            SERIAL PRIMARY KEY,
+  name          TEXT NOT NULL,
+  parent_group  TEXT NOT NULL CHECK (parent_group IN ('food', 'non_food')),
+  display_order INTEGER NOT NULL DEFAULT 1,
+  created_at    TIMESTAMP DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS items (
-  id SERIAL PRIMARY KEY,
-  name TEXT NOT NULL,
-  category_id INTEGER REFERENCES categories(id) ON DELETE SET NULL,
-  expiration_date DATE
-  quantity INTEGER NOT NULL CHECK (quantity > 0)
-)
+  id                  SERIAL PRIMARY KEY,
+  name                TEXT NOT NULL,
+  category_id         INTEGER REFERENCES categories(id) ON DELETE SET NULL,
+  low_stock_threshold INTEGER NOT NULL DEFAULT 10,
+  created_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS item_batches (
+  id              SERIAL PRIMARY KEY,
+  item_id         INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  expiration_date DATE,
+  quantity        INTEGER NOT NULL DEFAULT 1 CHECK (quantity >= 0),
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE items
+ADD COLUMN IF NOT EXISTS barcode VARCHAR(50);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_barcode
+ON items (barcode)
+WHERE barcode IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_item_batches_item_expiration
+ON item_batches (item_id, expiration_date);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_name
+ON categories (LOWER(name));

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -11,3 +11,17 @@ CREATE TABLE IF NOT EXISTS users (
   created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS categories (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS items (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  category_id INTEGER REFERENCES categories(id) ON DELETE SET NULL,
+  expiration_date DATE
+  quantity INTEGER NOT NULL CHECK (quantity > 0)
+)

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -51,6 +51,22 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_items_barcode
 ON items (barcode)
 WHERE barcode IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS item_barcodes (
+  id         SERIAL PRIMARY KEY,
+  item_id    INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  barcode    VARCHAR(50) NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO item_barcodes (item_id, barcode)
+SELECT id, barcode
+FROM items
+WHERE barcode IS NOT NULL
+ON CONFLICT (barcode) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_item_barcodes_item_id
+ON item_barcodes (item_id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_item_batches_item_expiration
 ON item_batches (item_id, expiration_date);
 

--- a/sql/create_tables_mysql.sql
+++ b/sql/create_tables_mysql.sql
@@ -15,3 +15,50 @@ CREATE TABLE IF NOT EXISTS users (
   UNIQUE KEY idx_username     (username),
   UNIQUE KEY idx_email        (email)
 );
+
+CREATE TABLE IF NOT EXISTS barcode_mappings (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  barcode     VARCHAR(50) NOT NULL,
+  custom_name VARCHAR(255) NOT NULL,
+  created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  UNIQUE KEY idx_barcode (barcode)
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  parent_group  VARCHAR(20) NOT NULL,
+  display_order INT NOT NULL DEFAULT 1,
+  created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS items (
+  id                  INT AUTO_INCREMENT PRIMARY KEY,
+  name                TEXT NOT NULL,
+  category_id         INT DEFAULT NULL,
+  low_stock_threshold INT NOT NULL DEFAULT 10,
+  created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_items_category
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+    ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS item_batches (
+  id              INT AUTO_INCREMENT PRIMARY KEY,
+  item_id         INT NOT NULL,
+  expiration_date DATE DEFAULT NULL,
+  quantity        INT NOT NULL DEFAULT 1,
+  created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_item_batches_item
+    FOREIGN KEY (item_id) REFERENCES items(id)
+    ON DELETE CASCADE,
+  CONSTRAINT chk_inventory_batch_quantity CHECK (quantity >= 0)
+);
+
+ALTER TABLE items
+ADD COLUMN IF NOT EXISTS barcode VARCHAR(50) DEFAULT NULL;
+
+CREATE UNIQUE INDEX idx_items_barcode ON items (barcode);
+CREATE UNIQUE INDEX idx_item_batches_item_expiration ON item_batches (item_id, expiration_date);

--- a/sql/migrate_v2.sql
+++ b/sql/migrate_v2.sql
@@ -1,0 +1,107 @@
+-- Migration v2: Restructure items into items + item_batches
+-- Run this in the Supabase SQL Editor (supabase.com → project → SQL Editor)
+
+-- 1. Add parent_group and display_order to categories
+ALTER TABLE categories
+  ADD COLUMN IF NOT EXISTS parent_group TEXT NOT NULL DEFAULT 'food'
+    CHECK (parent_group IN ('food', 'non_food')),
+  ADD COLUMN IF NOT EXISTS display_order INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Drop old items table (had expiration_date + quantity directly on item)
+DROP TABLE IF EXISTS item_batches;
+DROP TABLE IF EXISTS items;
+
+-- 3. New items table: master record with low_stock_threshold
+CREATE TABLE items (
+  id                  SERIAL PRIMARY KEY,
+  name                TEXT    NOT NULL,
+  category_id         INTEGER REFERENCES categories(id) ON DELETE SET NULL,
+  low_stock_threshold INTEGER NOT NULL DEFAULT 20,
+  created_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 4. item_batches: tracks individual batches with expiration dates
+CREATE TABLE item_batches (
+  id              SERIAL  PRIMARY KEY,
+  item_id         INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  expiration_date DATE,
+  quantity        INTEGER NOT NULL DEFAULT 0 CHECK (quantity >= 0),
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ─── Seed categories ──────────────────────────────────────────────────────────
+INSERT INTO categories (id, name, parent_group, display_order) VALUES
+  (1,  'Dairy',                          'food',     1),
+  (2,  'Canned Fruits and Vegetables',   'food',     2),
+  (3,  'Canned Meat',                    'food',     3),
+  (4,  'Pasta',                          'food',     4),
+  (5,  'Soup',                           'food',     5),
+  (6,  'Cooking Oil',                    'food',     6),
+  (7,  'Tree Nuts',                      'food',     7),
+  (8,  'Shellfish',                      'food',     8),
+  (9,  'Cleaning Supplies',              'non_food', 1),
+  (10, 'Household Goods',               'non_food', 2)
+ON CONFLICT (name) DO UPDATE SET
+  parent_group  = EXCLUDED.parent_group,
+  display_order = EXCLUDED.display_order;
+
+SELECT setval('categories_id_seq', (SELECT MAX(id) FROM categories));
+
+-- ─── Seed items ───────────────────────────────────────────────────────────────
+INSERT INTO items (id, name, category_id, low_stock_threshold) VALUES
+  (1,  'Cottage Cheese',        1,  20),
+  (2,  'Eggs',                  1,  20),
+  (3,  'Milk',                  1,  50),
+  (4,  'Canned Corn',           2,  30),
+  (5,  'Black Beans',           2,  30),
+  (6,  'Canned Broccoli',       2,  20),
+  (7,  'Canned Beef',           3,  20),
+  (8,  'Angel Hair Pasta',      4,  30),
+  (9,  'Penne Pasta',           4,  30),
+  (10, 'Chicken Noodle Soup',   5,  50),
+  (11, 'Tomato Soup',           5,  50),
+  (12, 'Alfredo Sauce',         4,  20),
+  (13, 'Kleenex Tissue Boxes',  9,  10),
+  (14, 'Beef Jerky',            3,  15),
+  (15, 'Bananas',               2,  30),
+  (16, 'Bacon',                 1,  20);
+
+SELECT setval('items_id_seq', (SELECT MAX(id) FROM items));
+
+-- ─── Seed item_batches ────────────────────────────────────────────────────────
+INSERT INTO item_batches (item_id, expiration_date, quantity) VALUES
+  -- Cottage Cheese (id=1): expired stock, qty 0
+  (1,  '2026-03-01', 0),
+  -- Eggs (id=2): spread across 2026
+  (2,  '2026-01-01', 22),
+  (2,  '2026-02-01', 22),
+  (2,  '2026-03-01', 22),
+  (2,  '2026-04-01', 0),
+  (2,  '2026-05-01', 0),
+  (2,  '2026-06-01', 22),
+  (2,  '2026-07-01', 22),
+  (2,  '2026-08-01', 22),
+  (2,  '2026-09-01', 22),
+  (2,  '2026-10-01', 22),
+  (2,  '2026-11-01', 22),
+  (2,  '2026-12-01', 0),
+  -- Milk (id=3)
+  (3,  '2026-06-01', 15),
+  -- Canned Corn (id=4)
+  (4,  '2027-01-01', 100),
+  -- Black Beans (id=5)
+  (5,  '2027-08-01', 45),
+  -- Angel Hair Pasta (id=8)
+  (8,  '2027-04-01', 67),
+  -- Penne Pasta (id=9)
+  (9,  '2027-03-01', 23),
+  -- Chicken Noodle Soup (id=10)
+  (10, '2027-05-01', 234),
+  (10, '2027-12-01', 389),
+  -- Tomato Soup (id=11)
+  (11, '2026-03-01', 43),
+  (11, '2027-06-01', 120),
+  -- Alfredo Sauce (id=12)
+  (12, '2027-05-01', 42),
+  -- Kleenex (id=13): no expiration
+  (13, NULL, 35);

--- a/sql/migrate_v3.sql
+++ b/sql/migrate_v3.sql
@@ -1,0 +1,13 @@
+-- Migration v3: Add activity_log table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id          SERIAL PRIMARY KEY,
+  item_id     INTEGER REFERENCES items(id) ON DELETE SET NULL,
+  item_name   TEXT NOT NULL,
+  action      TEXT NOT NULL CHECK (action IN ('added', 'removed')),
+  quantity    INTEGER NOT NULL CHECK (quantity > 0),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_created_at ON activity_log (created_at DESC);

--- a/sql/migrate_v4.sql
+++ b/sql/migrate_v4.sql
@@ -1,0 +1,18 @@
+-- Migration v4: Allow multiple barcodes per item
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE IF NOT EXISTS item_barcodes (
+  id         SERIAL PRIMARY KEY,
+  item_id    INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  barcode    VARCHAR(50) NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO item_barcodes (item_id, barcode)
+SELECT id, barcode
+FROM items
+WHERE barcode IS NOT NULL
+ON CONFLICT (barcode) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_item_barcodes_item_id
+ON item_barcodes (item_id);

--- a/sql/migrate_v5_reset_inventory_categories.sql
+++ b/sql/migrate_v5_reset_inventory_categories.sql
@@ -1,0 +1,31 @@
+-- Migration v5: Reset inventory items and replace category taxonomy
+-- Run this in the Supabase SQL Editor after migrate_v4.sql
+
+DELETE FROM item_batches;
+DELETE FROM item_barcodes;
+DELETE FROM items;
+DELETE FROM categories;
+
+ALTER SEQUENCE item_batches_id_seq RESTART WITH 1;
+ALTER SEQUENCE item_barcodes_id_seq RESTART WITH 1;
+ALTER SEQUENCE items_id_seq RESTART WITH 1;
+ALTER SEQUENCE categories_id_seq RESTART WITH 1;
+
+INSERT INTO categories (id, name, parent_group, display_order) VALUES
+  (1,  'Protein',                         'food',     1),
+  (2,  'Grains/Staples',                  'food',     2),
+  (3,  'Fruits and Vegetables',           'food',     3),
+  (4,  'Dairy',                           'food',     4),
+  (5,  'Frozen Foods',                    'food',     5),
+  (6,  'Meals/Prepared Foods',            'food',     6),
+  (7,  'Snacks',                          'food',     7),
+  (8,  'Breakfast Foods',                 'food',     8),
+  (9,  'Condiments & Cooking Essentials', 'food',     9),
+  (10, 'Specialty/Dietary Items',         'food',     10),
+  (11, 'Baby Items',                      'food',     11),
+  (12, 'Cleaning Supplies',               'non_food', 1),
+  (13, 'Personal Care',                   'non_food', 2),
+  (14, 'Paper Goods',                     'non_food', 3),
+  (15, 'Baby & Child',                    'non_food', 4);
+
+SELECT setval('categories_id_seq', (SELECT MAX(id) FROM categories));

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -12,7 +12,9 @@ const pgPool = new Pool({
   ssl: { rejectUnauthorized: false }, // required for Supabase
 });
 
-export { pgPool };
+// Export both names so older repositories that still import `pool`
+// keep working while the codebase converges on `pgPool`.
+export { pgPool, pgPool as pool };
 
 // === AWS RDS / MySQL (uncomment below and comment out the Postgres block above to switch) ===
 // Also update src/repositories/userRepository.js to use mysqlProvider.

--- a/src/controllers/activityController.js
+++ b/src/controllers/activityController.js
@@ -1,0 +1,38 @@
+import { pgPool } from '../config/database.js';
+
+const activityController = {
+  async getLogs(req, res) {
+    try {
+      const { start, end } = req.query;
+
+      const conditions = [];
+      const values = [];
+
+      if (start) {
+        values.push(start);
+        conditions.push(`created_at >= $${values.length}::date`);
+      }
+      if (end) {
+        values.push(end);
+        conditions.push(`created_at < ($${values.length}::date + INTERVAL '1 day')`);
+      }
+
+      const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      const { rows } = await pgPool.query(
+        `SELECT id, item_id, item_name, action, quantity, created_at
+         FROM activity_log
+         ${where}
+         ORDER BY created_at DESC`,
+        values
+      );
+
+      res.status(200).json(rows);
+    } catch (error) {
+      console.error('Get activity logs error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+};
+
+export default activityController;

--- a/src/controllers/barcodeController.js
+++ b/src/controllers/barcodeController.js
@@ -64,6 +64,24 @@ const lookupUpcItemDb = async (barcode) => {
   };
 };
 
+const lookupProvider = async (providerName, lookupFn, barcode) => {
+  try {
+    return await lookupFn(barcode);
+  } catch (error) {
+    if (error.response?.status === 429) {
+      console.warn(`${providerName} barcode lookup rate limit hit`);
+      return null;
+    }
+
+    if (error.response?.status === 404) {
+      return null;
+    }
+
+    console.warn(`${providerName} barcode lookup failed:`, error.message);
+    return null;
+  }
+};
+
 export const lookupBarcode = async (req, res) => {
   const { barcode } = req.body;
 
@@ -76,6 +94,8 @@ export const lookupBarcode = async (req, res) => {
     const existingItem = await getItemByBarcode(barcode);
     if (existingItem) {
       return res.json({
+        categoryId: existingItem.category_id,
+        categoryName: existingItem.category_name,
         productName: existingItem.name,
         source: 'database',
       });
@@ -91,18 +111,24 @@ export const lookupBarcode = async (req, res) => {
       });
     }
 
-    const openFoodFactsResult = await lookupOpenFoodFacts(barcode);
+    const openFoodFactsResult = await lookupProvider(
+      'Open Food Facts',
+      lookupOpenFoodFacts,
+      barcode
+    );
     if (openFoodFactsResult) {
       return res.json(openFoodFactsResult);
     }
 
-    // Optional paid fallback for products that Open Food Facts does not know
-    // about yet. Leaving this behind an env var keeps the default setup free.
-    if (UPCITEMDB_API_KEY) {
-      const upcItemDbResult = await lookupUpcItemDb(barcode);
-      if (upcItemDbResult) {
-        return res.json(upcItemDbResult);
-      }
+    // Free fallback for products that Open Food Facts does not know about yet.
+    // UPCItemDB allows no-key Explorer usage, and accepts user_key when present.
+    const upcItemDbResult = await lookupProvider(
+      'UPCItemDB',
+      lookupUpcItemDb,
+      barcode
+    );
+    if (upcItemDbResult) {
+      return res.json(upcItemDbResult);
     }
 
     return res.status(404).json({ error: 'Product not found' });

--- a/src/controllers/barcodeController.js
+++ b/src/controllers/barcodeController.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import {
   getBarcodeMapping,
+  getItemByBarcode,
   setBarcodeMapping,
 } from '../repositories/barcodeRepository.js';
 
@@ -71,6 +72,15 @@ export const lookupBarcode = async (req, res) => {
   }
 
   try {
+    // Check our own database first - existing items in inventory take priority
+    const existingItem = await getItemByBarcode(barcode);
+    if (existingItem) {
+      return res.json({
+        productName: existingItem.name,
+        source: 'database',
+      });
+    }
+
     // The admin nickname wins over any third-party catalog result. That keeps
     // the pantry's preferred naming consistent across future scans.
     const customMapping = await getBarcodeMapping(barcode);

--- a/src/controllers/barcodeController.js
+++ b/src/controllers/barcodeController.js
@@ -1,0 +1,127 @@
+import axios from 'axios';
+
+import {
+  getBarcodeMapping,
+  setBarcodeMapping,
+} from '../repositories/barcodeRepository.js';
+
+const OPEN_FOOD_FACTS_BASE_URL = 'https://world.openfoodfacts.org/api/v2/product';
+const OPEN_FOOD_FACTS_USER_AGENT =
+  process.env.OPEN_FOOD_FACTS_USER_AGENT || 'disc-food-pantry/1.0';
+const UPCITEMDB_API_KEY = process.env.UPCITEMDB_API_KEY;
+const UPCITEMDB_BASE_URL = 'https://api.upcitemdb.com/prod/trial/lookup';
+
+const lookupOpenFoodFacts = async (barcode) => {
+  const response = await axios.get(
+    `${OPEN_FOOD_FACTS_BASE_URL}/${encodeURIComponent(barcode)}`,
+    {
+      params: {
+        fields: 'product_name,product_name_en,generic_name,generic_name_en',
+      },
+      headers: {
+        'User-Agent': OPEN_FOOD_FACTS_USER_AGENT,
+      },
+    }
+  );
+
+  const product = response.data?.product;
+  const productName =
+    product?.product_name ||
+    product?.product_name_en ||
+    product?.generic_name ||
+    product?.generic_name_en ||
+    null;
+
+  if (!productName) {
+    return null;
+  }
+
+  return {
+    productName,
+    source: 'open_food_facts',
+  };
+};
+
+const lookupUpcItemDb = async (barcode) => {
+  const headers = UPCITEMDB_API_KEY
+    ? { user_key: UPCITEMDB_API_KEY }
+    : undefined;
+
+  const response = await axios.get(UPCITEMDB_BASE_URL, {
+    params: { upc: barcode },
+    headers,
+  });
+
+  const firstItem = response.data?.items?.[0];
+  if (!firstItem?.title) {
+    return null;
+  }
+
+  return {
+    productName: firstItem.title,
+    source: 'upcitemdb',
+  };
+};
+
+export const lookupBarcode = async (req, res) => {
+  const { barcode } = req.body;
+
+  if (!barcode) {
+    return res.status(400).json({ error: 'Barcode is required' });
+  }
+
+  try {
+    // The admin nickname wins over any third-party catalog result. That keeps
+    // the pantry's preferred naming consistent across future scans.
+    const customMapping = await getBarcodeMapping(barcode);
+    if (customMapping) {
+      return res.json({
+        productName: customMapping.custom_name,
+        source: 'custom',
+      });
+    }
+
+    const openFoodFactsResult = await lookupOpenFoodFacts(barcode);
+    if (openFoodFactsResult) {
+      return res.json(openFoodFactsResult);
+    }
+
+    // Optional paid fallback for products that Open Food Facts does not know
+    // about yet. Leaving this behind an env var keeps the default setup free.
+    if (UPCITEMDB_API_KEY) {
+      const upcItemDbResult = await lookupUpcItemDb(barcode);
+      if (upcItemDbResult) {
+        return res.json(upcItemDbResult);
+      }
+    }
+
+    return res.status(404).json({ error: 'Product not found' });
+  } catch (error) {
+    console.error('Error looking up barcode:', error);
+    if (error.response?.status === 404) {
+      return res.status(404).json({ error: 'Product not found' });
+    }
+    if (error.response?.status === 429) {
+      return res.status(503).json({ error: 'Barcode provider rate limit hit' });
+    }
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const setCustomName = async (req, res) => {
+  const { barcode, customName } = req.body;
+
+  if (!barcode || !customName) {
+    return res
+      .status(400)
+      .json({ error: 'Barcode and customName are required' });
+  }
+
+  try {
+    const mapping = await setBarcodeMapping(barcode, customName);
+    res.json({ message: 'Custom name set', mapping });
+  } catch (error) {
+    console.error('Error setting custom name:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/src/controllers/batchController.js
+++ b/src/controllers/batchController.js
@@ -5,6 +5,14 @@ const parseId = (idParam) => {
   return Number.isInteger(id) && id > 0 ? id : null;
 };
 
+async function logActivity(itemId, itemName, action, quantity) {
+  if (quantity <= 0) return;
+  await pgPool.query(
+    `INSERT INTO activity_log (item_id, item_name, action, quantity) VALUES ($1, $2, $3, $4)`,
+    [itemId, itemName, action, quantity]
+  );
+}
+
 const batchController = {
   async createBatch(req, res) {
     try {
@@ -19,9 +27,8 @@ const batchController = {
         return res.status(400).json({ error: 'Quantity must be a non-negative number' });
       }
 
-      // Verify item exists
       const { rows: itemRows } = await pgPool.query(
-        `SELECT id FROM items WHERE id = $1`,
+        `SELECT id, name FROM items WHERE id = $1`,
         [itemId]
       );
       if (itemRows.length === 0) {
@@ -33,6 +40,8 @@ const batchController = {
          VALUES ($1, $2, $3) RETURNING *`,
         [itemId, expiration_date || null, quantity]
       );
+
+      await logActivity(itemId, itemRows[0].name, 'added', quantity);
 
       res.status(201).json(rows[0]);
     } catch (error) {
@@ -54,6 +63,18 @@ const batchController = {
 
       if (quantity !== undefined && (typeof quantity !== 'number' || quantity < 0)) {
         return res.status(400).json({ error: 'Quantity must be a non-negative number' });
+      }
+
+      // Fetch current batch + item name before updating
+      const { rows: currentRows } = await pgPool.query(
+        `SELECT b.quantity, i.name AS item_name
+         FROM item_batches b
+         JOIN items i ON i.id = b.item_id
+         WHERE b.id = $1 AND b.item_id = $2`,
+        [batchId, itemId]
+      );
+      if (currentRows.length === 0) {
+        return res.status(404).json({ error: 'Batch not found' });
       }
 
       const updates = [];
@@ -82,8 +103,13 @@ const batchController = {
         values
       );
 
-      if (rows.length === 0) {
-        return res.status(404).json({ error: 'Batch not found' });
+      if (quantity !== undefined) {
+        const delta = quantity - currentRows[0].quantity;
+        if (delta > 0) {
+          await logActivity(itemId, currentRows[0].item_name, 'added', delta);
+        } else if (delta < 0) {
+          await logActivity(itemId, currentRows[0].item_name, 'removed', -delta);
+        }
       }
 
       res.status(200).json(rows[0]);
@@ -102,14 +128,24 @@ const batchController = {
         return res.status(400).json({ error: 'Invalid id' });
       }
 
-      const { rows } = await pgPool.query(
-        `DELETE FROM item_batches WHERE id=$1 AND item_id=$2 RETURNING id`,
+      // Fetch batch quantity + item name before deleting
+      const { rows: currentRows } = await pgPool.query(
+        `SELECT b.quantity, i.name AS item_name
+         FROM item_batches b
+         JOIN items i ON i.id = b.item_id
+         WHERE b.id = $1 AND b.item_id = $2`,
+        [batchId, itemId]
+      );
+      if (currentRows.length === 0) {
+        return res.status(404).json({ error: 'Batch not found' });
+      }
+
+      await pgPool.query(
+        `DELETE FROM item_batches WHERE id=$1 AND item_id=$2`,
         [batchId, itemId]
       );
 
-      if (rows.length === 0) {
-        return res.status(404).json({ error: 'Batch not found' });
-      }
+      await logActivity(itemId, currentRows[0].item_name, 'removed', currentRows[0].quantity);
 
       res.status(200).json({ message: 'Batch deleted successfully' });
     } catch (error) {

--- a/src/controllers/batchController.js
+++ b/src/controllers/batchController.js
@@ -1,0 +1,122 @@
+import { pgPool } from '../config/database.js';
+
+const parseId = (idParam) => {
+  const id = Number.parseInt(idParam, 10);
+  return Number.isInteger(id) && id > 0 ? id : null;
+};
+
+const batchController = {
+  async createBatch(req, res) {
+    try {
+      const itemId = parseId(req.params.itemId);
+      if (!itemId) {
+        return res.status(400).json({ error: 'Invalid item id' });
+      }
+
+      const { expiration_date, quantity = 0 } = req.body;
+
+      if (typeof quantity !== 'number' || quantity < 0) {
+        return res.status(400).json({ error: 'Quantity must be a non-negative number' });
+      }
+
+      // Verify item exists
+      const { rows: itemRows } = await pgPool.query(
+        `SELECT id FROM items WHERE id = $1`,
+        [itemId]
+      );
+      if (itemRows.length === 0) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+
+      const { rows } = await pgPool.query(
+        `INSERT INTO item_batches (item_id, expiration_date, quantity)
+         VALUES ($1, $2, $3) RETURNING *`,
+        [itemId, expiration_date || null, quantity]
+      );
+
+      res.status(201).json(rows[0]);
+    } catch (error) {
+      console.error('Create batch error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async updateBatch(req, res) {
+    try {
+      const itemId = parseId(req.params.itemId);
+      const batchId = parseId(req.params.batchId);
+
+      if (!itemId || !batchId) {
+        return res.status(400).json({ error: 'Invalid id' });
+      }
+
+      const { expiration_date, quantity } = req.body;
+
+      if (quantity !== undefined && (typeof quantity !== 'number' || quantity < 0)) {
+        return res.status(400).json({ error: 'Quantity must be a non-negative number' });
+      }
+
+      const updates = [];
+      const values = [];
+      let idx = 1;
+
+      if (expiration_date !== undefined) {
+        updates.push(`expiration_date=$${idx++}`);
+        values.push(expiration_date || null);
+      }
+      if (quantity !== undefined) {
+        updates.push(`quantity=$${idx++}`);
+        values.push(quantity);
+      }
+
+      if (updates.length === 0) {
+        return res.status(400).json({ error: 'No fields to update' });
+      }
+
+      values.push(batchId, itemId);
+      const { rows } = await pgPool.query(
+        `UPDATE item_batches
+         SET ${updates.join(', ')}
+         WHERE id=$${idx} AND item_id=$${idx + 1}
+         RETURNING *`,
+        values
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Batch not found' });
+      }
+
+      res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error('Update batch error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async deleteBatch(req, res) {
+    try {
+      const itemId = parseId(req.params.itemId);
+      const batchId = parseId(req.params.batchId);
+
+      if (!itemId || !batchId) {
+        return res.status(400).json({ error: 'Invalid id' });
+      }
+
+      const { rows } = await pgPool.query(
+        `DELETE FROM item_batches WHERE id=$1 AND item_id=$2 RETURNING id`,
+        [batchId, itemId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Batch not found' });
+      }
+
+      res.status(200).json({ message: 'Batch deleted successfully' });
+    } catch (error) {
+      console.error('Delete batch error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+};
+
+export default batchController;

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -111,6 +111,8 @@ const categoriesController = {
   },
 
   async deleteCategory(req, res) {
+    const client = await pgPool.connect();
+
     try {
       const categoryId = parseCategoryId(req.params.id);
 
@@ -118,19 +120,65 @@ const categoriesController = {
         return res.status(400).json({ error: 'Invalid category id' });
       }
 
-      const { rows } = await pgPool.query(
+      await client.query('BEGIN');
+
+      const { rows: categoryRows } = await client.query(
+        `SELECT id
+         FROM categories
+         WHERE id = $1`,
+        [categoryId]
+      );
+
+      if (categoryRows.length === 0) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Category not found' });
+      }
+
+      const { rows: itemRows } = await client.query(
+        `SELECT
+           i.id,
+           i.name,
+           COALESCE(SUM(b.quantity), 0)::int AS total_quantity
+         FROM items i
+         LEFT JOIN item_batches b ON b.item_id = i.id
+         WHERE i.category_id = $1
+         GROUP BY i.id`,
+        [categoryId]
+      );
+
+      for (const item of itemRows) {
+        if (item.total_quantity > 0) {
+          await client.query(
+            `INSERT INTO activity_log (item_id, item_name, action, quantity)
+             VALUES ($1, $2, 'removed', $3)`,
+            [item.id, item.name, item.total_quantity]
+          );
+        }
+      }
+
+      await client.query(
+        `DELETE FROM items
+         WHERE category_id = $1`,
+        [categoryId]
+      );
+
+      await client.query(
         `DELETE FROM categories
          WHERE id = $1
          RETURNING id`,
         [categoryId]
       );
 
-      if (rows.length === 0) {
-        return res.status(404).json({ error: 'Category not found' });
-      }
+      await client.query('COMMIT');
 
-      res.status(200).json({ message: 'Category deleted successfully' });
+      res.status(200).json({
+        message: 'Category deleted successfully',
+        deletedItemCount: itemRows.length,
+        loggedItemCount: itemRows.filter((item) => item.total_quantity > 0)
+          .length,
+      });
     } catch (error) {
+      await client.query('ROLLBACK');
       console.error('Delete category error:', error);
       if (error.code === '23503') {
         return res.status(409).json({
@@ -138,6 +186,8 @@ const categoriesController = {
         });
       }
       res.status(500).json({ error: 'Internal server error' });
+    } finally {
+      client.release();
     }
   },
 };

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -114,25 +114,10 @@ const categoriesController = {
     const client = await pgPool.connect();
 
     try {
-      await client.query('BEGIN');
+      const categoryId = parseCategoryId(req.params.id);
 
-      const { rows: itemRows } = await client.query(
-        `SELECT i.id, i.name, COALESCE(SUM(b.quantity), 0)::int AS total_quantity
-         FROM items i
-         LEFT JOIN item_batches b ON b.item_id = i.id
-         WHERE i.category_id = $1
-         GROUP BY i.id, i.name`,
-        [categoryId]
-      );
-
-      for (const item of itemRows) {
-        if (item.total_quantity > 0) {
-          await client.query(
-            `INSERT INTO activity_log (item_id, item_name, action, quantity)
-             VALUES (NULL, $1, 'removed', $2)`,
-            [item.name, item.total_quantity]
-          );
-        }
+      if (!categoryId) {
+        return res.status(400).json({ error: 'Invalid category id' });
       }
 
       await client.query('BEGIN');

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -1,0 +1,141 @@
+import { pgPool } from '../config/database.js';
+
+const parseCategoryId = (idParam) => {
+  const id = Number.parseInt(idParam, 10);
+  return Number.isInteger(id) && id > 0 ? id : null;
+};
+
+const categoriesController = {
+  async getAllCategories(_req, res) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT id, name, created_at AS "createdAt"
+         FROM categories
+         ORDER BY name ASC`
+      );
+
+      res.status(200).json(rows);
+    } catch (error) {
+      console.error('Get categories error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async getCategoryById(req, res) {
+    try {
+      const categoryId = parseCategoryId(req.params.id);
+
+      if (!categoryId) {
+        return res.status(400).json({ error: 'Invalid category id' });
+      }
+
+      const { rows } = await pgPool.query(
+        `SELECT id, name, created_at AS "createdAt"
+         FROM categories
+         WHERE id = $1`,
+        [categoryId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Category not found' });
+      }
+
+      res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error('Get category by id error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async createCategory(req, res) {
+    try {
+      const name = req.body.name?.trim();
+
+      if (!name) {
+        return res.status(400).json({ error: 'Category name is required' });
+      }
+
+      const { rows } = await pgPool.query(
+        `INSERT INTO categories (name)
+         VALUES ($1)
+         RETURNING id, name, created_at AS "createdAt"`,
+        [name]
+      );
+
+      res.status(201).json(rows[0]);
+    } catch (error) {
+      console.error('Create category error:', error);
+      if (error.code === '23505') {
+        return res.status(409).json({ error: 'Category name already exists' });
+      }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async updateCategory(req, res) {
+    try {
+      const categoryId = parseCategoryId(req.params.id);
+      const name = req.body.name?.trim();
+
+      if (!categoryId) {
+        return res.status(400).json({ error: 'Invalid category id' });
+      }
+      if (!name) {
+        return res.status(400).json({ error: 'Category name is required' });
+      }
+
+      const { rows } = await pgPool.query(
+        `UPDATE categories
+         SET name = $1
+         WHERE id = $2
+         RETURNING id, name, created_at AS "createdAt"`,
+        [name, categoryId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Category not found' });
+      }
+
+      res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error('Update category error:', error);
+      if (error.code === '23505') {
+        return res.status(409).json({ error: 'Category name already exists' });
+      }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async deleteCategory(req, res) {
+    try {
+      const categoryId = parseCategoryId(req.params.id);
+
+      if (!categoryId) {
+        return res.status(400).json({ error: 'Invalid category id' });
+      }
+
+      const { rows } = await pgPool.query(
+        `DELETE FROM categories
+         WHERE id = $1
+         RETURNING id`,
+        [categoryId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Category not found' });
+      }
+
+      res.status(200).json({ message: 'Category deleted successfully' });
+    } catch (error) {
+      console.error('Delete category error:', error);
+      if (error.code === '23503') {
+        return res.status(409).json({
+          error: 'Cannot delete category with related items',
+        });
+      }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+};
+
+export default categoriesController;

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -111,26 +111,53 @@ const categoriesController = {
   },
 
   async deleteCategory(req, res) {
+    const categoryId = parseCategoryId(req.params.id);
+
+    if (!categoryId) {
+      return res.status(400).json({ error: 'Invalid category id' });
+    }
+
+    const client = await pgPool.connect();
     try {
-      const categoryId = parseCategoryId(req.params.id);
+      await client.query('BEGIN');
 
-      if (!categoryId) {
-        return res.status(400).json({ error: 'Invalid category id' });
-      }
-
-      const { rows } = await pgPool.query(
-        `DELETE FROM categories
-         WHERE id = $1
-         RETURNING id`,
+      const { rows: itemRows } = await client.query(
+        `SELECT i.id, i.name, COALESCE(SUM(b.quantity), 0)::int AS total_quantity
+         FROM items i
+         LEFT JOIN item_batches b ON b.item_id = i.id
+         WHERE i.category_id = $1
+         GROUP BY i.id, i.name`,
         [categoryId]
       );
 
-      if (rows.length === 0) {
+      for (const item of itemRows) {
+        if (item.total_quantity > 0) {
+          await client.query(
+            `INSERT INTO activity_log (item_id, item_name, action, quantity)
+             VALUES (NULL, $1, 'removed', $2)`,
+            [item.name, item.total_quantity]
+          );
+        }
+      }
+
+      await client.query(`DELETE FROM items WHERE category_id = $1`, [
+        categoryId,
+      ]);
+
+      const { rows: deletedCategory } = await client.query(
+        `DELETE FROM categories WHERE id = $1 RETURNING id`,
+        [categoryId]
+      );
+
+      if (deletedCategory.length === 0) {
+        await client.query('ROLLBACK');
         return res.status(404).json({ error: 'Category not found' });
       }
 
+      await client.query('COMMIT');
       res.status(200).json({ message: 'Category deleted successfully' });
     } catch (error) {
+      await client.query('ROLLBACK');
       console.error('Delete category error:', error);
       if (error.code === '23503') {
         return res.status(409).json({
@@ -138,6 +165,8 @@ const categoriesController = {
         });
       }
       res.status(500).json({ error: 'Internal server error' });
+    } finally {
+      client.release();
     }
   },
 };

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -9,9 +9,9 @@ const categoriesController = {
   async getAllCategories(_req, res) {
     try {
       const { rows } = await pgPool.query(
-        `SELECT id, name, created_at AS "createdAt"
+        `SELECT id, name, parent_group, display_order, created_at AS "createdAt"
          FROM categories
-         ORDER BY name ASC`
+         ORDER BY display_order ASC, name ASC`
       );
 
       res.status(200).json(rows);
@@ -50,16 +50,20 @@ const categoriesController = {
   async createCategory(req, res) {
     try {
       const name = req.body.name?.trim();
+      const { parent_group = 'food', display_order = 0 } = req.body;
 
       if (!name) {
         return res.status(400).json({ error: 'Category name is required' });
       }
+      if (!['food', 'non_food'].includes(parent_group)) {
+        return res.status(400).json({ error: 'parent_group must be food or non_food' });
+      }
 
       const { rows } = await pgPool.query(
-        `INSERT INTO categories (name)
-         VALUES ($1)
-         RETURNING id, name, created_at AS "createdAt"`,
-        [name]
+        `INSERT INTO categories (name, parent_group, display_order)
+         VALUES ($1, $2, $3)
+         RETURNING id, name, parent_group, display_order, created_at AS "createdAt"`,
+        [name, parent_group, display_order]
       );
 
       res.status(201).json(rows[0]);

--- a/src/controllers/inventoryController.js
+++ b/src/controllers/inventoryController.js
@@ -1,5 +1,6 @@
 import {
   checkInInventoryItem,
+  checkOutInventoryItem,
   createCategory,
   getCategoriesWithItems,
   getItemDetailById,
@@ -164,6 +165,80 @@ const inventoryController = {
       if (error.code === '23503') {
         return res.status(400).json({ error: 'categoryId does not exist' });
       }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async checkOut(req, res) {
+    try {
+      const { barcode, itemId, quantity } = req.body;
+
+      const normalizedQuantity = parsePositiveInteger(quantity, null);
+      if (normalizedQuantity === null) {
+        return res
+          .status(400)
+          .json({ error: 'quantity must be a positive integer' });
+      }
+
+      const hasBarcode =
+        typeof barcode === 'string' && barcode.trim().length > 0;
+      const normalizedItemId =
+        itemId === undefined || itemId === null || itemId === ''
+          ? null
+          : parsePositiveInteger(itemId, null);
+      if (itemId !== undefined && itemId !== null && itemId !== '' && normalizedItemId === null) {
+        return res
+          .status(400)
+          .json({ error: 'itemId must be a positive integer' });
+      }
+
+      if (!hasBarcode && normalizedItemId === null) {
+        return res
+          .status(400)
+          .json({ error: 'barcode or itemId is required' });
+      }
+
+      let result;
+      try {
+        result = await checkOutInventoryItem({
+          barcode: hasBarcode ? barcode.trim() : null,
+          itemId: normalizedItemId,
+          quantity: normalizedQuantity,
+        });
+      } catch (error) {
+        if (error.code === 'BARCODE_NOT_FOUND') {
+          return res.status(404).json({
+            error: 'No item is registered for this barcode',
+            code: 'BARCODE_NOT_FOUND',
+            barcode: error.barcode,
+          });
+        }
+        if (error.code === 'ITEM_NOT_FOUND') {
+          return res
+            .status(404)
+            .json({ error: 'Item not found', code: 'ITEM_NOT_FOUND' });
+        }
+        if (error.code === 'INSUFFICIENT_STOCK') {
+          return res.status(409).json({
+            error: 'Insufficient stock for the requested quantity',
+            code: 'INSUFFICIENT_STOCK',
+            requested: error.requested,
+            available: error.available,
+          });
+        }
+        throw error;
+      }
+
+      const itemDetail = await getItemDetailById(result.item.id);
+
+      res.status(200).json({
+        message: 'Inventory item checked out successfully',
+        item: itemDetail,
+        removed: result.removed,
+        batchesAffected: result.batchesAffected,
+      });
+    } catch (error) {
+      console.error('Inventory check-out error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   },

--- a/src/controllers/inventoryController.js
+++ b/src/controllers/inventoryController.js
@@ -1,0 +1,172 @@
+import {
+  checkInInventoryItem,
+  createCategory,
+  getCategoriesWithItems,
+  getItemDetailById,
+} from '../repositories/inventoryRepository.js';
+
+const parsePositiveInteger = (value, fallback) => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const inventoryController = {
+  async listCategories(req, res) {
+    try {
+      const { parentGroup } = req.query;
+      const categories = await getCategoriesWithItems(parentGroup);
+      res.json(categories);
+    } catch (error) {
+      console.error('List inventory categories error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async createCategory(req, res) {
+    try {
+      const { name, parentGroup, displayOrder } = req.body;
+
+      if (!name || !parentGroup) {
+        return res
+          .status(400)
+          .json({ error: 'name and parentGroup are required' });
+      }
+
+      if (!['food', 'non_food'].includes(parentGroup)) {
+        return res
+          .status(400)
+          .json({ error: 'parentGroup must be food or non_food' });
+      }
+
+      const normalizedDisplayOrder = parsePositiveInteger(displayOrder, 1);
+      if (normalizedDisplayOrder === null) {
+        return res
+          .status(400)
+          .json({ error: 'displayOrder must be a positive integer' });
+      }
+
+      const category = await createCategory({
+        name: name.trim(),
+        parentGroup,
+        displayOrder: normalizedDisplayOrder,
+      });
+
+      res.status(201).json(category);
+    } catch (error) {
+      console.error('Create inventory category error:', error);
+      if (error.code === '23505' || error.code === 'ER_DUP_ENTRY') {
+        return res.status(400).json({ error: 'Category name already exists' });
+      }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async getItemDetail(req, res) {
+    try {
+      const itemId = Number.parseInt(req.params.itemId, 10);
+
+      if (!Number.isInteger(itemId)) {
+        return res.status(400).json({ error: 'itemId must be an integer' });
+      }
+
+      const item = await getItemDetailById(itemId);
+      if (!item) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+
+      res.json(item);
+    } catch (error) {
+      console.error('Get inventory item detail error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async checkIn(req, res) {
+    try {
+      const {
+        barcode,
+        name,
+        expirationDate,
+        quantity,
+        categoryId,
+        lowStockThreshold,
+      } = req.body;
+
+      if (!name || !expirationDate) {
+        return res
+          .status(400)
+          .json({ error: 'name and expirationDate are required' });
+      }
+
+      const normalizedQuantity = parsePositiveInteger(quantity, 1);
+      if (normalizedQuantity === null) {
+        return res
+          .status(400)
+          .json({ error: 'quantity must be a positive integer' });
+      }
+
+      const normalizedCategoryId =
+        categoryId === undefined || categoryId === null || categoryId === ''
+          ? null
+          : parsePositiveInteger(categoryId, null);
+      if (categoryId !== undefined && normalizedCategoryId === null) {
+        return res
+          .status(400)
+          .json({ error: 'categoryId must be a positive integer' });
+      }
+
+      const normalizedLowStockThreshold = parsePositiveInteger(
+        lowStockThreshold,
+        10
+      );
+      if (normalizedLowStockThreshold === null) {
+        return res
+          .status(400)
+          .json({ error: 'lowStockThreshold must be a positive integer' });
+      }
+
+      const parsedExpirationDate = new Date(expirationDate);
+      if (Number.isNaN(parsedExpirationDate.getTime())) {
+        return res
+          .status(400)
+          .json({ error: 'expirationDate must be a valid date' });
+      }
+
+      // We store the batch date in YYYY-MM-DD format so multiple check-ins for
+      // the same day collapse into one batch row instead of drifting apart due
+      // to timezone offsets in ISO timestamps.
+      const normalizedExpirationDate = parsedExpirationDate
+        .toISOString()
+        .slice(0, 10);
+
+      const result = await checkInInventoryItem({
+        barcode,
+        name: name.trim(),
+        expirationDate: normalizedExpirationDate,
+        quantity: normalizedQuantity,
+        categoryId: normalizedCategoryId,
+        lowStockThreshold: normalizedLowStockThreshold,
+      });
+
+      const itemDetail = await getItemDetailById(result.item.id);
+
+      res.status(201).json({
+        message: 'Inventory item checked in successfully',
+        item: itemDetail,
+        batch: result.batch,
+      });
+    } catch (error) {
+      console.error('Inventory check-in error:', error);
+      if (error.code === '23503') {
+        return res.status(400).json({ error: 'categoryId does not exist' });
+      }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+};
+
+export default inventoryController;

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -137,14 +137,21 @@ const itemController = {
       }
 
       values.push(itemId);
-      const { rows } = await pgPool.query(
-        `UPDATE items SET ${updates.join(', ')} WHERE id=$${idx} RETURNING *`,
+      const { rowCount } = await pgPool.query(
+        `UPDATE items SET ${updates.join(', ')} WHERE id=$${idx}`,
         values
       );
 
-      if (rows.length === 0) {
+      if (rowCount === 0) {
         return res.status(404).json({ error: 'Item not found' });
       }
+
+      const { rows } = await pgPool.query(
+        `${ITEM_SELECT}
+         WHERE i.id = $1
+         GROUP BY i.id, c.name`,
+        [itemId]
+      );
 
       res.status(200).json(rows[0]);
     } catch (error) {

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -16,6 +16,9 @@ const ITEM_SELECT = `
     i.created_at,
     c.name AS category_name,
     COALESCE(SUM(b.quantity), 0)::int AS total_quantity,
+    MIN(b.expiration_date) FILTER (
+      WHERE b.quantity > 0 AND b.expiration_date IS NOT NULL
+    ) AS earliest_expiration,
     CASE
       WHEN COALESCE(SUM(b.quantity), 0) = 0                        THEN 'out_of_stock'
       WHEN COALESCE(SUM(b.quantity), 0) <= i.low_stock_threshold   THEN 'low_stock'

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -1,0 +1,132 @@
+import { pgPool } from '../config/database.js';
+
+const parseItemId = (idParam) => {
+  const id = Number.parseInt(idParam, 10);
+  return Number.isInteger(id) && id > 0 ? id : null;
+};
+
+const itemController = {
+  async getAllItems(_req, res) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT i.*, c.name AS category_name
+         FROM items i
+         LEFT JOIN categories c ON i.category_id = c.id`
+      );
+      res.status(200).json(rows);
+    } catch (error) {
+      console.error('Get items error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async getItemById(req, res) {
+    try {
+      const itemId = parseItemId(req.params.id);
+      if (!itemId) {
+        return res.status(400).json({ error: 'Invalid item id' });
+      }
+
+      const { rows } = await pgPool.query(
+        `SELECT i.*, c.name AS category_name
+         FROM items i
+         LEFT JOIN categories c ON i.category_id = c.id
+         WHERE i.id = $1`,
+        [itemId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+
+      res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error('Get item by id error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async createItem(req, res) {
+    try {
+      const name = req.body.name?.trim();
+      const { category_id, expiration_date, quantity } = req.body;
+
+      if (!name) {
+        return res.status(400).json({ error: 'Item name is required' });
+      }
+      if (!quantity || quantity < 0) {
+        return res.status(400).json({ error: 'Valid quantity is required' });
+      }
+
+      const { rows } = await pgPool.query(
+        `INSERT INTO items (name, category_id, expiration_date, quantity)
+         VALUES ($1, $2, $3, $4) RETURNING *`,
+        [name, category_id, expiration_date, quantity]
+      );
+
+      res.status(201).json(rows[0]);
+    } catch (error) {
+      console.error('Create item error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async updateItem(req, res) {
+    try {
+      const itemId = parseItemId(req.params.id);
+      const name = req.body.name?.trim();
+      const { category_id, expiration_date, quantity } = req.body;
+
+      if (!itemId) {
+        return res.status(400).json({ error: 'Invalid item id' });
+      }
+      if (!name) {
+        return res.status(400).json({ error: 'Item name is required' });
+      }
+      if (!quantity || quantity < 0) {
+        return res.status(400).json({ error: 'Valid quantity is required' });
+      }
+
+      const { rows } = await pgPool.query(
+        `UPDATE items
+         SET name=$1, category_id=$2, expiration_date=$3, quantity=$4
+         WHERE id=$5 RETURNING *`,
+        [name, category_id, expiration_date, quantity, itemId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+
+      res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error('Update item error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async deleteItem(req, res) {
+    try {
+      const itemId = parseItemId(req.params.id);
+      if (!itemId) {
+        return res.status(400).json({ error: 'Invalid item id' });
+      }
+
+      const { rows } = await pgPool.query(
+        `DELETE FROM items WHERE id=$1 RETURNING id`,
+        [itemId]
+      );
+
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+
+      res.status(200).json({ message: 'Item deleted successfully' });
+    } catch (error) {
+      console.error('Delete item error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+};
+
+export default itemController;

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -9,6 +9,13 @@ const parseItemId = (idParam) => {
 const ITEM_SELECT = `
   SELECT
     i.id,
+    (
+      SELECT ib.barcode
+      FROM item_barcodes ib
+      WHERE ib.item_id = i.id
+      ORDER BY ib.created_at ASC, ib.id ASC
+      LIMIT 1
+    ) AS barcode,
     i.name,
     i.category_id,
     i.low_stock_threshold,
@@ -66,7 +73,19 @@ const itemController = {
         [itemId]
       );
 
-      res.status(200).json({ ...itemRows[0], batches: batchRows });
+      const { rows: barcodeRows } = await pgPool.query(
+        `SELECT id, barcode, created_at
+         FROM item_barcodes
+         WHERE item_id = $1
+         ORDER BY created_at ASC, id ASC`,
+        [itemId]
+      );
+
+      res.status(200).json({
+        ...itemRows[0],
+        batches: batchRows,
+        barcodes: barcodeRows,
+      });
     } catch (error) {
       console.error('Get item by id error:', error);
       res.status(500).json({ error: 'Internal server error' });

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -10,6 +10,7 @@ const ITEM_SELECT = `
   SELECT
     i.id,
     i.name,
+    i.barcode,
     i.category_id,
     i.low_stock_threshold,
     i.created_at,

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -17,7 +17,6 @@ const ITEM_SELECT = `
       LIMIT 1
     ) AS barcode,
     i.name,
-    i.barcode,
     i.category_id,
     i.low_stock_threshold,
     i.created_at,

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -5,13 +5,33 @@ const parseItemId = (idParam) => {
   return Number.isInteger(id) && id > 0 ? id : null;
 };
 
+// Shared SELECT fragment: item with computed total_quantity and status
+const ITEM_SELECT = `
+  SELECT
+    i.id,
+    i.name,
+    i.category_id,
+    i.low_stock_threshold,
+    i.created_at,
+    c.name AS category_name,
+    COALESCE(SUM(b.quantity), 0)::int AS total_quantity,
+    CASE
+      WHEN COALESCE(SUM(b.quantity), 0) = 0                        THEN 'out_of_stock'
+      WHEN COALESCE(SUM(b.quantity), 0) <= i.low_stock_threshold   THEN 'low_stock'
+      ELSE 'normal'
+    END AS status
+  FROM items i
+  LEFT JOIN categories c ON i.category_id = c.id
+  LEFT JOIN item_batches b ON b.item_id = i.id
+`;
+
 const itemController = {
   async getAllItems(_req, res) {
     try {
       const { rows } = await pgPool.query(
-        `SELECT i.*, c.name AS category_name
-         FROM items i
-         LEFT JOIN categories c ON i.category_id = c.id`
+        `${ITEM_SELECT}
+         GROUP BY i.id, c.name
+         ORDER BY i.name ASC`
       );
       res.status(200).json(rows);
     } catch (error) {
@@ -27,19 +47,26 @@ const itemController = {
         return res.status(400).json({ error: 'Invalid item id' });
       }
 
-      const { rows } = await pgPool.query(
-        `SELECT i.*, c.name AS category_name
-         FROM items i
-         LEFT JOIN categories c ON i.category_id = c.id
-         WHERE i.id = $1`,
+      const { rows: itemRows } = await pgPool.query(
+        `${ITEM_SELECT}
+         WHERE i.id = $1
+         GROUP BY i.id, c.name`,
         [itemId]
       );
 
-      if (rows.length === 0) {
+      if (itemRows.length === 0) {
         return res.status(404).json({ error: 'Item not found' });
       }
 
-      res.status(200).json(rows[0]);
+      const { rows: batchRows } = await pgPool.query(
+        `SELECT id, item_id, expiration_date, quantity, created_at
+         FROM item_batches
+         WHERE item_id = $1
+         ORDER BY expiration_date ASC NULLS LAST, id ASC`,
+        [itemId]
+      );
+
+      res.status(200).json({ ...itemRows[0], batches: batchRows });
     } catch (error) {
       console.error('Get item by id error:', error);
       res.status(500).json({ error: 'Internal server error' });
@@ -49,22 +76,25 @@ const itemController = {
   async createItem(req, res) {
     try {
       const name = req.body.name?.trim();
-      const { category_id, expiration_date, quantity } = req.body;
+      const { category_id, low_stock_threshold = 20 } = req.body;
 
       if (!name) {
         return res.status(400).json({ error: 'Item name is required' });
       }
-      if (!quantity || quantity < 0) {
-        return res.status(400).json({ error: 'Valid quantity is required' });
-      }
 
       const { rows } = await pgPool.query(
-        `INSERT INTO items (name, category_id, expiration_date, quantity)
-         VALUES ($1, $2, $3, $4) RETURNING *`,
-        [name, category_id, expiration_date, quantity]
+        `INSERT INTO items (name, category_id, low_stock_threshold)
+         VALUES ($1, $2, $3) RETURNING *`,
+        [name, category_id || null, low_stock_threshold]
       );
 
-      res.status(201).json(rows[0]);
+      res.status(201).json({
+        ...rows[0],
+        category_name: null,
+        total_quantity: 0,
+        status: 'out_of_stock',
+        batches: [],
+      });
     } catch (error) {
       console.error('Create item error:', error);
       res.status(500).json({ error: 'Internal server error' });
@@ -74,24 +104,42 @@ const itemController = {
   async updateItem(req, res) {
     try {
       const itemId = parseItemId(req.params.id);
-      const name = req.body.name?.trim();
-      const { category_id, expiration_date, quantity } = req.body;
-
       if (!itemId) {
         return res.status(400).json({ error: 'Invalid item id' });
       }
-      if (!name) {
-        return res.status(400).json({ error: 'Item name is required' });
-      }
-      if (!quantity || quantity < 0) {
-        return res.status(400).json({ error: 'Valid quantity is required' });
+
+      const { name: rawName, category_id, low_stock_threshold } = req.body;
+      const name = rawName?.trim();
+
+      if (name !== undefined && !name) {
+        return res.status(400).json({ error: 'Item name cannot be empty' });
       }
 
+      const updates = [];
+      const values = [];
+      let idx = 1;
+
+      if (name !== undefined) {
+        updates.push(`name=$${idx++}`);
+        values.push(name);
+      }
+      if (category_id !== undefined) {
+        updates.push(`category_id=$${idx++}`);
+        values.push(category_id || null);
+      }
+      if (low_stock_threshold !== undefined) {
+        updates.push(`low_stock_threshold=$${idx++}`);
+        values.push(low_stock_threshold);
+      }
+
+      if (updates.length === 0) {
+        return res.status(400).json({ error: 'No fields to update' });
+      }
+
+      values.push(itemId);
       const { rows } = await pgPool.query(
-        `UPDATE items
-         SET name=$1, category_id=$2, expiration_date=$3, quantity=$4
-         WHERE id=$5 RETURNING *`,
-        [name, category_id, expiration_date, quantity, itemId]
+        `UPDATE items SET ${updates.join(', ')} WHERE id=$${idx} RETURNING *`,
+        values
       );
 
       if (rows.length === 0) {

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -30,4 +30,13 @@ const authMiddleware = async (req, res, next) => {
   }
 };
 
+// Volunteers sign in anonymously; any other Firebase sign-in provider counts
+// as an owner under the existing role model. Use after authMiddleware.
+export const requireOwner = (req, res, next) => {
+  if (req.user?.firebase?.sign_in_provider === 'anonymous') {
+    return res.status(403).json({ error: 'Owner access required' });
+  }
+  next();
+};
+
 export default authMiddleware;

--- a/src/repositories/barcodeRepository.js
+++ b/src/repositories/barcodeRepository.js
@@ -14,8 +14,9 @@ export const getItemByBarcode = async (barcode) => {
       c.id AS category_id,
       c.name AS category_name
     FROM items i
+    INNER JOIN item_barcodes ib ON ib.item_id = i.id
     LEFT JOIN categories c ON c.id = i.category_id
-    WHERE i.barcode = $1
+    WHERE ib.barcode = $1
     LIMIT 1;
   `;
   const result = await pgPool.query(query, [barcode]);

--- a/src/repositories/barcodeRepository.js
+++ b/src/repositories/barcodeRepository.js
@@ -6,6 +6,14 @@ export const getBarcodeMapping = async (barcode) => {
   return result.rows[0] || null;
 };
 
+export const getItemByBarcode = async (barcode) => {
+  const query = `
+    SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;
+  `;
+  const result = await pgPool.query(query, [barcode]);
+  return result.rows[0] || null;
+};
+
 export const setBarcodeMapping = async (barcode, customName) => {
   const query = `
     INSERT INTO barcode_mappings (barcode, custom_name)

--- a/src/repositories/barcodeRepository.js
+++ b/src/repositories/barcodeRepository.js
@@ -8,7 +8,15 @@ export const getBarcodeMapping = async (barcode) => {
 
 export const getItemByBarcode = async (barcode) => {
   const query = `
-    SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;
+    SELECT
+      i.id,
+      i.name,
+      c.id AS category_id,
+      c.name AS category_name
+    FROM items i
+    LEFT JOIN categories c ON c.id = i.category_id
+    WHERE i.barcode = $1
+    LIMIT 1;
   `;
   const result = await pgPool.query(query, [barcode]);
   return result.rows[0] || null;

--- a/src/repositories/barcodeRepository.js
+++ b/src/repositories/barcodeRepository.js
@@ -1,0 +1,20 @@
+import { pgPool } from '../config/database.js';
+
+export const getBarcodeMapping = async (barcode) => {
+  const query = 'SELECT custom_name FROM barcode_mappings WHERE barcode = $1';
+  const result = await pgPool.query(query, [barcode]);
+  return result.rows[0] || null;
+};
+
+export const setBarcodeMapping = async (barcode, customName) => {
+  const query = `
+    INSERT INTO barcode_mappings (barcode, custom_name)
+    VALUES ($1, $2)
+    ON CONFLICT (barcode) DO UPDATE SET
+      custom_name = EXCLUDED.custom_name,
+      updated_at = NOW()
+    RETURNING *;
+  `;
+  const result = await pgPool.query(query, [barcode, customName]);
+  return result.rows[0];
+};

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -360,7 +360,11 @@ export const checkOutInventoryItem = async ({ barcode, itemId, quantity }) => {
       }
     } else {
       const result = await client.query(
-        `SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;`,
+        `SELECT i.id, i.name
+           FROM items i
+           INNER JOIN item_barcodes ib ON ib.item_id = i.id
+          WHERE ib.barcode = $1
+          LIMIT 1;`,
         [barcode]
       );
       itemRow = result.rows[0];

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -3,7 +3,13 @@ import { pgPool } from '../config/database.js';
 const INVENTORY_SELECT = `
   SELECT
     i.id,
-    i.barcode,
+    (
+      SELECT ib.barcode
+      FROM item_barcodes ib
+      WHERE ib.item_id = i.id
+      ORDER BY ib.created_at ASC, ib.id ASC
+      LIMIT 1
+    ) AS barcode,
     i.name,
     i.low_stock_threshold,
     i.created_at,
@@ -143,9 +149,17 @@ export const getItemDetailById = async (itemId) => {
     ORDER BY expiration_date ASC NULLS LAST, id ASC;
   `;
 
-  const [itemResult, batchesResult] = await Promise.all([
+  const barcodesQuery = `
+    SELECT id, barcode, created_at
+    FROM item_barcodes
+    WHERE item_id = $1
+    ORDER BY created_at ASC, id ASC;
+  `;
+
+  const [itemResult, batchesResult, barcodesResult] = await Promise.all([
     pgPool.query(itemQuery, [itemId]),
     pgPool.query(batchesQuery, [itemId]),
+    pgPool.query(barcodesQuery, [itemId]),
   ]);
 
   const row = itemResult.rows[0];
@@ -176,6 +190,7 @@ export const getItemDetailById = async (itemId) => {
       expiration_date: batch.expiration_date,
       quantity: Number(batch.quantity),
     })),
+    barcodes: barcodesResult.rows,
   };
 };
 
@@ -198,9 +213,15 @@ export const checkInInventoryItem = async ({
     if (normalizedBarcode) {
       const existingItemResult = await client.query(
         `
-          SELECT id, barcode, name, category_id, low_stock_threshold
-          FROM items
-          WHERE barcode = $1
+          SELECT
+            i.id,
+            ib.barcode,
+            i.name,
+            i.category_id,
+            i.low_stock_threshold
+          FROM items i
+          INNER JOIN item_barcodes ib ON ib.item_id = i.id
+          WHERE ib.barcode = $1
           LIMIT 1;
         `,
         [normalizedBarcode]
@@ -209,27 +230,56 @@ export const checkInInventoryItem = async ({
       if (existingItemResult.rows[0]) {
         const itemResult = await client.query(
           `
-          UPDATE items
-          SET
-            name = $2,
-            category_id = COALESCE($3, category_id),
-            low_stock_threshold = $4
-          WHERE barcode = $1
-          RETURNING id, barcode, name, category_id, low_stock_threshold;
-        `,
-          [normalizedBarcode, name, categoryId, lowStockThreshold]
+            UPDATE items
+            SET
+              name = $2,
+              category_id = COALESCE($3, category_id),
+              low_stock_threshold = $4
+            WHERE id = $1
+            RETURNING id, name, category_id, low_stock_threshold;
+          `,
+          [
+            existingItemResult.rows[0].id,
+            name,
+            categoryId,
+            lowStockThreshold,
+          ]
         );
-        item = itemResult.rows[0];
+        item = { ...itemResult.rows[0], barcode: normalizedBarcode };
       } else {
-        const itemResult = await client.query(
+        const matchingItemResult = await client.query(
           `
-            INSERT INTO items (barcode, name, category_id, low_stock_threshold)
-            VALUES ($1, $2, $3, $4)
+            SELECT id, name, category_id, low_stock_threshold
+            FROM items
+            WHERE LOWER(name) = LOWER($1)
+              AND category_id IS NOT DISTINCT FROM $2
+            LIMIT 1;
+          `,
+          [name, categoryId]
+        );
+
+        if (matchingItemResult.rows[0]) {
+          item = matchingItemResult.rows[0];
+        } else {
+          const itemResult = await client.query(
+            `
+            INSERT INTO items (name, category_id, low_stock_threshold)
+            VALUES ($1, $2, $3)
             RETURNING id, barcode, name, category_id, low_stock_threshold;
           `,
-          [normalizedBarcode, name, categoryId, lowStockThreshold]
+            [name, categoryId, lowStockThreshold]
+          );
+          item = itemResult.rows[0];
+        }
+
+        await client.query(
+          `
+            INSERT INTO item_barcodes (item_id, barcode)
+            VALUES ($1, $2);
+          `,
+          [item.id, normalizedBarcode]
         );
-        item = itemResult.rows[0];
+        item = { ...item, barcode: normalizedBarcode };
       }
     } else {
       // When there is no barcode, we still avoid duplicate catalog rows by

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -1,0 +1,291 @@
+import { pgPool } from '../config/database.js';
+
+const INVENTORY_SELECT = `
+  SELECT
+    i.id,
+    i.barcode,
+    i.name,
+    i.low_stock_threshold,
+    i.created_at,
+    c.id AS category_id,
+    c.name AS category_name,
+    c.parent_group,
+    c.display_order,
+    COALESCE(SUM(b.quantity), 0) AS total_quantity
+  FROM items i
+  LEFT JOIN categories c ON c.id = i.category_id
+  LEFT JOIN item_batches b ON b.item_id = i.id
+`;
+
+const normalizeOptionalBarcode = (barcode) => {
+  if (typeof barcode !== 'string') {
+    return null;
+  }
+
+  const trimmed = barcode.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const buildInventoryStatus = (totalQuantity, lowStockThreshold) => {
+  if (totalQuantity <= 0) {
+    return 'out_of_stock';
+  }
+
+  if (totalQuantity <= lowStockThreshold) {
+    return 'low_stock';
+  }
+
+  return 'normal';
+};
+
+const mapItemSummary = (row) => {
+  const totalQuantity = Number(row.total_quantity);
+  const lowStockThreshold = Number(row.low_stock_threshold);
+
+  return {
+    id: row.id,
+    barcode: row.barcode,
+    name: row.name,
+    total_quantity: totalQuantity,
+    low_stock_threshold: lowStockThreshold,
+    status: buildInventoryStatus(totalQuantity, lowStockThreshold),
+  };
+};
+
+export const getCategoriesWithItems = async (parentGroup) => {
+  const values = [];
+  let whereClause = '';
+
+  if (parentGroup) {
+    values.push(parentGroup);
+    whereClause = 'WHERE c.parent_group = $1';
+  }
+
+  const categoryQuery = `
+    SELECT
+      c.id,
+      c.name,
+      c.parent_group,
+      c.display_order
+    FROM categories c
+    ${whereClause}
+    ORDER BY c.parent_group ASC, c.display_order ASC, c.name ASC;
+  `;
+
+  const itemQuery = `
+    ${INVENTORY_SELECT}
+    ${whereClause}
+    GROUP BY
+      i.id,
+      c.id,
+      c.name,
+      c.parent_group,
+      c.display_order
+    ORDER BY LOWER(i.name) ASC;
+  `;
+
+  const [categoriesResult, itemsResult] = await Promise.all([
+    pgPool.query(categoryQuery, values),
+    pgPool.query(itemQuery, values),
+  ]);
+
+  const itemsByCategoryId = new Map();
+  for (const row of itemsResult.rows) {
+    if (!row.category_id) {
+      continue;
+    }
+
+    const existingItems = itemsByCategoryId.get(row.category_id) || [];
+    existingItems.push(mapItemSummary(row));
+    itemsByCategoryId.set(row.category_id, existingItems);
+  }
+
+  return categoriesResult.rows.map((category) => ({
+    id: category.id,
+    name: category.name,
+    parent_group: category.parent_group,
+    display_order: category.display_order,
+    items: itemsByCategoryId.get(category.id) || [],
+  }));
+};
+
+export const createCategory = async ({
+  name,
+  parentGroup,
+  displayOrder,
+}) => {
+  const query = `
+    INSERT INTO categories (name, parent_group, display_order)
+    VALUES ($1, $2, $3)
+    RETURNING id, name, parent_group, display_order;
+  `;
+
+  const { rows } = await pgPool.query(query, [name, parentGroup, displayOrder]);
+  return rows[0];
+};
+
+export const getItemDetailById = async (itemId) => {
+  const itemQuery = `
+    ${INVENTORY_SELECT}
+    WHERE i.id = $1
+    GROUP BY
+      i.id,
+      c.id,
+      c.name,
+      c.parent_group,
+      c.display_order;
+  `;
+
+  const batchesQuery = `
+    SELECT id, expiration_date, quantity
+    FROM item_batches
+    WHERE item_id = $1
+    ORDER BY expiration_date ASC NULLS LAST, id ASC;
+  `;
+
+  const [itemResult, batchesResult] = await Promise.all([
+    pgPool.query(itemQuery, [itemId]),
+    pgPool.query(batchesQuery, [itemId]),
+  ]);
+
+  const row = itemResult.rows[0];
+  if (!row) {
+    return null;
+  }
+
+  const totalQuantity = Number(row.total_quantity);
+  const lowStockThreshold = Number(row.low_stock_threshold);
+
+  return {
+    id: row.id,
+    barcode: row.barcode,
+    name: row.name,
+    category: row.category_id
+      ? {
+          id: row.category_id,
+          name: row.category_name,
+          parent_group: row.parent_group,
+          display_order: row.display_order,
+        }
+      : null,
+    total_quantity: totalQuantity,
+    low_stock_threshold: lowStockThreshold,
+    status: buildInventoryStatus(totalQuantity, lowStockThreshold),
+    batches: batchesResult.rows.map((batch) => ({
+      id: batch.id,
+      expiration_date: batch.expiration_date,
+      quantity: Number(batch.quantity),
+    })),
+  };
+};
+
+export const checkInInventoryItem = async ({
+  barcode,
+  name,
+  expirationDate,
+  quantity,
+  categoryId = null,
+  lowStockThreshold = 10,
+}) => {
+  const client = await pgPool.connect();
+  const normalizedBarcode = normalizeOptionalBarcode(barcode);
+
+  try {
+    await client.query('BEGIN');
+
+    let item;
+
+    if (normalizedBarcode) {
+      const existingItemResult = await client.query(
+        `
+          SELECT id, barcode, name, category_id, low_stock_threshold
+          FROM items
+          WHERE barcode = $1
+          LIMIT 1;
+        `,
+        [normalizedBarcode]
+      );
+
+      if (existingItemResult.rows[0]) {
+        const itemResult = await client.query(
+          `
+          UPDATE items
+          SET
+            name = $2,
+            category_id = COALESCE($3, category_id),
+            low_stock_threshold = $4
+          WHERE barcode = $1
+          RETURNING id, barcode, name, category_id, low_stock_threshold;
+        `,
+          [normalizedBarcode, name, categoryId, lowStockThreshold]
+        );
+        item = itemResult.rows[0];
+      } else {
+        const itemResult = await client.query(
+          `
+            INSERT INTO items (barcode, name, category_id, low_stock_threshold)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, barcode, name, category_id, low_stock_threshold;
+          `,
+          [normalizedBarcode, name, categoryId, lowStockThreshold]
+        );
+        item = itemResult.rows[0];
+      }
+    } else {
+      // When there is no barcode, we still avoid duplicate catalog rows by
+      // reusing an item with the same name/category combination if one exists.
+      const existingItemResult = await client.query(
+        `
+          SELECT id, barcode, name, category_id, low_stock_threshold
+          FROM items
+          WHERE LOWER(name) = LOWER($1)
+            AND category_id IS NOT DISTINCT FROM $2
+          LIMIT 1;
+        `,
+        [name, categoryId]
+      );
+
+      if (existingItemResult.rows[0]) {
+        item = existingItemResult.rows[0];
+      } else {
+        const newItemResult = await client.query(
+          `
+            INSERT INTO items (barcode, name, category_id, low_stock_threshold)
+            VALUES (NULL, $1, $2, $3)
+            RETURNING id, barcode, name, category_id, low_stock_threshold;
+          `,
+          [name, categoryId, lowStockThreshold]
+        );
+        item = newItemResult.rows[0];
+      }
+    }
+
+    const batchResult = await client.query(
+      `
+        INSERT INTO item_batches (item_id, expiration_date, quantity)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (item_id, expiration_date) DO UPDATE SET
+          quantity = item_batches.quantity + EXCLUDED.quantity
+        RETURNING id, item_id, expiration_date, quantity;
+      `,
+      [item.id, expirationDate, quantity]
+    );
+
+    await client.query('COMMIT');
+
+    return {
+      item,
+      batch: {
+        id: batchResult.rows[0].id,
+        item_id: batchResult.rows[0].item_id,
+        expiration_date: batchResult.rows[0].expiration_date,
+        quantity: Number(batchResult.rows[0].quantity),
+      },
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -289,3 +289,113 @@ export const checkInInventoryItem = async ({
     client.release();
   }
 };
+
+export const checkOutInventoryItem = async ({ barcode, itemId, quantity }) => {
+  const client = await pgPool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    let itemRow;
+    if (itemId) {
+      const result = await client.query(
+        `SELECT id, name FROM items WHERE id = $1 LIMIT 1;`,
+        [itemId]
+      );
+      itemRow = result.rows[0];
+      if (!itemRow) {
+        const err = new Error('Item not found');
+        err.code = 'ITEM_NOT_FOUND';
+        throw err;
+      }
+    } else {
+      const result = await client.query(
+        `SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;`,
+        [barcode]
+      );
+      itemRow = result.rows[0];
+      if (!itemRow) {
+        const err = new Error('No item registered for this barcode');
+        err.code = 'BARCODE_NOT_FOUND';
+        err.barcode = barcode;
+        throw err;
+      }
+    }
+
+    // FOR UPDATE locks the matched batch rows for the duration of this
+    // transaction so a concurrent checkout cannot read the same stock and
+    // double-decrement it.
+    const batchesResult = await client.query(
+      `SELECT id, expiration_date, quantity
+         FROM item_batches
+        WHERE item_id = $1
+        ORDER BY expiration_date ASC NULLS LAST, id ASC
+        FOR UPDATE;`,
+      [itemRow.id]
+    );
+
+    const available = batchesResult.rows.reduce(
+      (sum, row) => sum + Number(row.quantity),
+      0
+    );
+
+    if (available < quantity) {
+      const err = new Error('Insufficient stock');
+      err.code = 'INSUFFICIENT_STOCK';
+      err.requested = quantity;
+      err.available = available;
+      throw err;
+    }
+
+    let remaining = quantity;
+    const batchesAffected = [];
+
+    for (const batch of batchesResult.rows) {
+      if (remaining === 0) break;
+
+      const batchQty = Number(batch.quantity);
+      if (batchQty === 0) continue;
+
+      const take = Math.min(batchQty, remaining);
+      const newQty = batchQty - take;
+      remaining -= take;
+
+      if (newQty === 0) {
+        await client.query(`DELETE FROM item_batches WHERE id = $1;`, [
+          batch.id,
+        ]);
+      } else {
+        await client.query(
+          `UPDATE item_batches SET quantity = $1 WHERE id = $2;`,
+          [newQty, batch.id]
+        );
+      }
+
+      batchesAffected.push({
+        id: batch.id,
+        expiration_date: batch.expiration_date,
+        quantity_removed: take,
+        remaining: newQty,
+      });
+    }
+
+    await client.query(
+      `INSERT INTO activity_log (item_id, item_name, action, quantity)
+       VALUES ($1, $2, 'removed', $3);`,
+      [itemRow.id, itemRow.name, quantity]
+    );
+
+    await client.query('COMMIT');
+
+    return {
+      item: itemRow,
+      removed: quantity,
+      batchesAffected,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+import activityController from '../controllers/activityController.js';
+
+const router = Router();
+
+router.get('/', activityController.getLogs);
+
+export default router;

--- a/src/routes/barcodeRoutes.js
+++ b/src/routes/barcodeRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+
+import {
+  lookupBarcode,
+  setCustomName,
+} from '../controllers/barcodeController.js';
+
+const router = express.Router();
+
+router.post('/lookup', lookupBarcode);
+router.post('/set-custom', setCustomName);
+
+export default router;

--- a/src/routes/categoriesRoutes.js
+++ b/src/routes/categoriesRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+
+import categoriesController from '../controllers/categories.js';
+
+const router = express.Router();
+
+router.get('/', categoriesController.getAllCategories);
+router.get('/:id', categoriesController.getCategoryById);
+router.post('/', categoriesController.createCategory);
+router.put('/:id', categoriesController.updateCategory);
+router.delete('/:id', categoriesController.deleteCategory);
+
+export default router;

--- a/src/routes/inventoryRoutes.js
+++ b/src/routes/inventoryRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+
+import inventoryController from '../controllers/inventoryController.js';
+
+const router = express.Router();
+
+router.get('/categories', inventoryController.listCategories);
+router.post('/categories', inventoryController.createCategory);
+router.get('/items/:itemId', inventoryController.getItemDetail);
+router.post('/check-in', inventoryController.checkIn);
+
+export default router;

--- a/src/routes/inventoryRoutes.js
+++ b/src/routes/inventoryRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import inventoryController from '../controllers/inventoryController.js';
+import authMiddleware, { requireOwner } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
@@ -8,5 +9,11 @@ router.get('/categories', inventoryController.listCategories);
 router.post('/categories', inventoryController.createCategory);
 router.get('/items/:itemId', inventoryController.getItemDetail);
 router.post('/check-in', inventoryController.checkIn);
+router.post(
+  '/check-out',
+  authMiddleware,
+  requireOwner,
+  inventoryController.checkOut
+);
 
 export default router;

--- a/src/routes/itemRoutes.js
+++ b/src/routes/itemRoutes.js
@@ -1,12 +1,20 @@
 import { Router } from 'express';
+
+import batchController from '../controllers/batchController.js';
 import itemController from '../controllers/itemController.js';
 
 const router = Router();
 
+// Item CRUD
 router.get('/', itemController.getAllItems);
 router.get('/:id', itemController.getItemById);
 router.post('/', itemController.createItem);
 router.put('/:id', itemController.updateItem);
 router.delete('/:id', itemController.deleteItem);
+
+// Batch CRUD (nested under item)
+router.post('/:itemId/batches', batchController.createBatch);
+router.put('/:itemId/batches/:batchId', batchController.updateBatch);
+router.delete('/:itemId/batches/:batchId', batchController.deleteBatch);
 
 export default router;

--- a/src/routes/itemRoutes.js
+++ b/src/routes/itemRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import itemController from '../controllers/itemController.js';
+
+const router = Router();
+
+router.get('/', itemController.getAllItems);
+router.get('/:id', itemController.getItemById);
+router.post('/', itemController.createItem);
+router.put('/:id', itemController.updateItem);
+router.delete('/:id', itemController.deleteItem);
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import express from 'express';
 
 import authRoutes from './routes/authRoutes.js';
 import categoriesRoutes from './routes/categoriesRoutes.js';
+import itemRoutes from './routes/itemRoutes.js';
 
 dotenv.config();
 
@@ -41,6 +42,7 @@ app.use((req, res, next) => {
 
 app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
+app.use('/items', itemRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,8 @@ import express from 'express';
 import authRoutes from './routes/authRoutes.js';
 import categoriesRoutes from './routes/categoriesRoutes.js';
 import itemRoutes from './routes/itemRoutes.js';
+import barcodeRoutes from './routes/barcodeRoutes.js';
+import inventoryRoutes from './routes/inventoryRoutes.js';
 
 dotenv.config();
 
@@ -49,6 +51,8 @@ app.use((req, res, next) => {
 app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
 app.use('/items', itemRoutes);
+app.use('/api/barcode', barcodeRoutes);
+app.use('/api/inventory', inventoryRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.js
+++ b/src/server.js
@@ -14,8 +14,6 @@ const corsOptions = {
     const allowedOrigins = [
       process.env.FRONTEND_URL,
       process.env.FRONTEND_URL_DEV,
-      'http://localhost:5173',
-      'https://localhost:5173',
     ];
 
     if (allowedOrigins.includes(origin) || !origin) {

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,8 @@ const corsOptions = {
     const allowedOrigins = [
       process.env.FRONTEND_URL,
       process.env.FRONTEND_URL_DEV,
+      'http://localhost:5173',
+      'https://localhost:5173',
     ];
 
     if (allowedOrigins.includes(origin) || !origin) {

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
 
+import activityRoutes from './routes/activityRoutes.js';
 import authRoutes from './routes/authRoutes.js';
 import categoriesRoutes from './routes/categoriesRoutes.js';
 import itemRoutes from './routes/itemRoutes.js';
@@ -49,6 +50,7 @@ app.use((req, res, next) => {
 app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
 app.use('/items', itemRoutes);
+app.use('/activity', activityRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import express from 'express';
 
 import authRoutes from './routes/authRoutes.js';
+import categoriesRoutes from './routes/categoriesRoutes.js';
 
 dotenv.config();
 
@@ -39,6 +40,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/auth', authRoutes);
+app.use('/categories', categoriesRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.js
+++ b/src/server.js
@@ -18,7 +18,11 @@ const corsOptions = {
       process.env.FRONTEND_URL_DEV,
       'http://localhost:5173',
       'https://localhost:5173',
-    ];
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+      'http://localhost:3000',
+      'http://127.0.0.1:3000',
+    ].filter(Boolean);
 
     if (allowedOrigins.includes(origin) || !origin) {
       callback(null, true);

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,8 @@ app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
 app.use('/items', itemRoutes);
 app.use('/activity', activityRoutes);
+app.use('/api/inventory', inventoryRoutes);
+app.use('/api/barcode', barcodeRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,8 @@ app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
 app.use('/items', itemRoutes);
 app.use('/activity', activityRoutes);
+app.use('/api/barcode', barcodeRoutes);
+app.use('/api/inventory', inventoryRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });


### PR DESCRIPTION
Three fixes after PR #17 merged. The merge crashed the server and broke two scan-out related queries.

## Fixes

1. **`fix(categories)`**: GitHub web-editor conflict resolution stacked both my and Cameron's `deleteCategory` instead of picking one — duplicate `const itemRows`, double `BEGIN`, missing `parseCategoryId`. Server couldn't start. Restored `categories.js` to `7afa8e5` (Cameron's working version, the agreed resolution).

2. **`fix(scan-out)`**: `/api/inventory/check-out` looked up barcodes via `items.barcode`, which PR #15 stopped populating. Now joins through `item_barcodes`, mirroring `checkInInventoryItem`.

3. **`fix(items)`**: `ITEM_SELECT` had two `barcode` columns (Cameron's subquery alias + my leftover `i.barcode`). pg-driver's last-wins mapping made every item return `barcode: null`. Dropped the duplicate.

## Verification

`node --check` passes on all three files. `categories.js` pre-fix failed to parse under ESM; post-fix is clean. No other call sites affected.

## Known unrelated issue

`createItem` still spreads `RETURNING *` and exposes legacy `items.barcode`. Pre-existing from PR #15, not in scope here.